### PR TITLE
Use Sequel instead of raw OCI8 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ config/certs
 .rvmrc
 Gemfile.lock
 pkg
-
+db/

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -51,12 +51,10 @@ module Dor
     # @option opts [String] :db_uri ('WORKFLOW_DB_URI') Database uri
     # @option opts [String] :wf_table ('workflow') Name of the active workflow table
     # @option opts [String] :wfa_table ('workflow_archive') Name of the workflow archive table
-    # @option opts [String] :dor_service_uri ('DOR_SERVICE_URI') URI of the DOR Rest service
     # @option opts [Integer] :retry_delay (5) Number of seconds to sleep between retries of database operations
     def initialize(opts = {})
       @conn = opts[:db_connection]
       @db_uri                 = opts.fetch(:db_uri, WorkflowArchiver.config.db_uri).freeze
-      @dor_service_uri        = opts.include?(:dor_service_uri) ? opts[:dor_service_uri] : WorkflowArchiver.config.dor_service_uri
       @workflow_table         = opts.include?(:wf_table)    ? opts[:wf_table]    : 'workflow'
       @workflow_archive_table = opts.include?(:wfa_table)   ? opts[:wfa_table]   : 'workflow_archive'
       @retry_delay            = opts.include?(:retry_delay) ? opts[:retry_delay] : 5

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -54,6 +54,7 @@ module Dor
     # @option opts [String] :dor_service_uri ('DOR_SERVICE_URI') URI of the DOR Rest service
     # @option opts [Integer] :retry_delay (5) Number of seconds to sleep between retries of database operations
     def initialize(opts = {})
+      @conn = opts[:db_connection]
       @db_uri                 = opts.fetch(:db_uri, WorkflowArchiver.config.db_uri).freeze
       @dor_service_uri        = opts.include?(:dor_service_uri) ? opts[:dor_service_uri] : WorkflowArchiver.config.dor_service_uri
       @workflow_table         = opts.include?(:wf_table)    ? opts[:wf_table]    : 'workflow'

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -1,17 +1,16 @@
 require 'rest_client'
 require 'confstruct'
 require 'lyber_core'
-require 'oci8'
+require 'sequel'
 
 module Dor
   # Holds the paramaters about the workflow rows that need to be deleted
   ArchiveCriteria = Struct.new(:repository, :druid, :datastream, :version) do
     # @param [Array<Hash>] List of objects returned from {WorkflowArchiver#find_completed_objects}.  It expects the following keys in the hash
-    #  "REPOSITORY", "DRUID", "DATASTREAM".  Note they are all caps strings, not symbols
     def setup_from_query(row_hash)
-      self.repository = row_hash['REPOSITORY']
-      self.druid      = row_hash['DRUID']
-      self.datastream = row_hash['DATASTREAM']
+      self.repository = row_hash[:repository]
+      self.druid = row_hash[:druid]
+      self.datastream = row_hash[:datastream]
       set_current_version
       self
     end
@@ -21,7 +20,7 @@ module Dor
     def to_bind_hash
       h = {}
       members.reject { |mem| mem =~ /version/ }.each do |m|
-        h[m.swapcase] = send(m) if send(m)
+        h[m] = send(m) if send(m)
       end
       h
     end
@@ -37,10 +36,10 @@ module Dor
   end
 
   class WorkflowArchiver
-    WF_COLUMNS = %w(ID DRUID DATASTREAM PROCESS STATUS ERROR_MSG ERROR_TXT DATETIME ATTEMPTS LIFECYCLE ELAPSED REPOSITORY NOTE PRIORITY LANE_ID)
+    WF_COLUMNS = %w(id druid datastream process status error_msg error_txt datetime attempts lifecycle elapsed repository note priority lane_id)
 
     # These attributes mostly used for testing
-    attr_reader :conn, :errors
+    attr_reader :errors
 
     def self.config
       @@conf ||= Confstruct::Configuration.new
@@ -49,17 +48,13 @@ module Dor
     # Sets up logging and connects to the database.  By default it reads values from constants:
     #  WORKFLOW_DB_LOGIN, WORKFLOW_DB_PASSWORD, WORKFLOW_DB_URI, DOR_SERVICE_URI but can be overriden with the opts Hash
     # @param [Hash] opts Options to override database parameters
-    # @option opts [String] :login ('WORKFLOW_DB_LOGIN') Database login id
-    # @option opts [String] :password ('WORKFLOW_DB_PASSWORD') Database password
     # @option opts [String] :db_uri ('WORKFLOW_DB_URI') Database uri
     # @option opts [String] :wf_table ('workflow') Name of the active workflow table
     # @option opts [String] :wfa_table ('workflow_archive') Name of the workflow archive table
     # @option opts [String] :dor_service_uri ('DOR_SERVICE_URI') URI of the DOR Rest service
     # @option opts [Integer] :retry_delay (5) Number of seconds to sleep between retries of database operations
     def initialize(opts = {})
-      @login                  = opts.include?(:login)       ? opts[:login]       : WorkflowArchiver.config.db_login
-      @password               = opts.include?(:password)    ? opts[:password]    : WorkflowArchiver.config.db_password
-      @db_uri                 = opts.include?(:db_uri)      ? opts[:db_uri]      : WorkflowArchiver.config.db_uri
+      @db_uri                 = opts.fetch(:db_uri, WorkflowArchiver.config.db_uri).freeze
       @dor_service_uri        = opts.include?(:dor_service_uri) ? opts[:dor_service_uri] : WorkflowArchiver.config.dor_service_uri
       @workflow_table         = opts.include?(:wf_table)    ? opts[:wf_table]    : 'workflow'
       @workflow_archive_table = opts.include?(:wfa_table)   ? opts[:wfa_table]   : 'workflow_archive'
@@ -69,38 +64,18 @@ module Dor
       @archived = 0
     end
 
-    def connect_to_db
-      $odb_pool ||= OCI8::ConnectionPool.new(1, 5, 2, @login, @password, @db_uri)
-      @conn = OCI8.new(@login, @password, $odb_pool)
-      @conn.autocommit = false
-    end
-
-    def destroy_pool
-      $odb_pool.destroy if $odb_pool
-    end
-
-    def bind_and_exec_sql(sql, workflow_info)
-      # LyberCore::Log.debug("Executing: #{sql}")
-      cursor = @conn.parse(sql)
-      workflow_info.to_bind_hash.each do |k, v|
-        param = ":#{k}"
-        # LyberCore::Log.debug("Setting: #{param} #{v}")
-        cursor.bind_param(param, v)
-      end
-      num_rows = cursor.exec
-      fail 'Expected more than 0 rows to be updated' unless num_rows > 0
-    ensure
-      cursor.close
+    def conn
+      @conn ||= Sequel.connect(@db_uri)
     end
 
     # @return [String] The columns appended with comma and newline
     def wf_column_string
-      WF_COLUMNS.inject('') { |str, col| str << col << ",\n" }
+      WF_COLUMNS.join(",\n")
     end
 
     # @return [String] The columns prepended with 'w.' and appended with comma and newline
     def wf_archive_column_string
-      WF_COLUMNS.inject('') { |str, col| str << 'w.' << col << ",\n" }
+      WF_COLUMNS.map { |col| "#{@workflow_table}.#{col}" }.join(",\n")
     end
 
     # Use this as a one-shot method to archive all the steps of an object's particular datastream
@@ -112,17 +87,14 @@ module Dor
     # @param [String] version
     def archive_one_datastream(repository, druid, datastream, version)
       criteria = [ArchiveCriteria.new(repository, druid, datastream, version)]
-      connect_to_db
       archive_rows criteria
-    ensure
-      @conn.logoff if @conn
     end
 
     # Copies rows from the workflow table to the workflow_archive table, then deletes the rows from workflow
     # Both operations must complete, or they get rolled back
     # @param [Array<ArchiveCriteria>] objs List of objects returned from {#find_completed_objects} and mapped to an array of ArchiveCriteria objects.
     def archive_rows(objs)
-      Array(objs).each do |obj|
+      objs.each do |obj|
         tries = 0
         begin
           tries += 1
@@ -130,7 +102,6 @@ module Dor
           @archived += 1
         rescue => e
           LyberCore::Log.error "Rolling back transaction due to: #{e.inspect}\n" << e.backtrace.join("\n") << "\n!!!!!!!!!!!!!!!!!!"
-          @conn.rollback
           if tries < 3 # Retry this druid up to 3 times
             LyberCore::Log.error "  Retrying archive operation in #{@retry_delay} seconds..."
             sleep @retry_delay
@@ -152,36 +123,42 @@ module Dor
       LyberCore::Log.info "Archiving #{workflow_info.inspect}"
       copy_sql = <<-EOSQL
         insert into #{@workflow_archive_table} (
-          #{wf_column_string}
-          VERSION
+          #{wf_column_string},
+          version
         )
         select
-          #{wf_archive_column_string}
-          #{workflow_info.version} as VERSION
-        from #{@workflow_table} w
-        where w.druid =    :DRUID
-        and w.datastream = :DATASTREAM
+          #{wf_archive_column_string},
+          #{workflow_info.version} as version
+        from #{@workflow_table}
+        where #{@workflow_table}.druid =    :druid
+        and #{@workflow_table}.datastream = :datastream
       EOSQL
 
-      delete_sql = "delete #{@workflow_table} where druid = :DRUID and datastream = :DATASTREAM "
+      delete_sql = "delete from #{@workflow_table} where druid = :druid and datastream = :datastream "
 
-      if workflow_info.repository
-        copy_sql << 'and w.repository = :REPOSITORY'
-        delete_sql << 'and repository = :REPOSITORY'
+      if(workflow_info.repository)
+        copy_sql += "and #{@workflow_table}.repository = :repository"
+        delete_sql += 'and repository = :repository'
       else
-        copy_sql << 'and w.repository IS NULL'
-        delete_sql << 'and repository IS NULL'
+        copy_sql += "and #{@workflow_table}.repository IS NULL"
+        delete_sql += 'and repository IS NULL'
       end
-      bind_and_exec_sql(copy_sql, workflow_info)
-      LyberCore::Log.debug '  Removing old workflow rows'
-      bind_and_exec_sql(delete_sql, workflow_info)
-      @conn.commit
+
+      conn.transaction do
+        conn.run Sequel::SQL::PlaceholderLiteralString.new(copy_sql, workflow_info.to_bind_hash)
+
+        LyberCore::Log.debug '  Removing old workflow rows'
+
+        conn.run Sequel::SQL::PlaceholderLiteralString.new(delete_sql, workflow_info.to_bind_hash)
+      end
     end
 
     # Finds objects where all workflow steps are complete
     # @return [Array<Hash{String=>String}>] each hash returned has the following keys:
     #   {"REPOSITORY"=>"dor", "DRUID"=>"druid:345", "DATASTREAM"=>"googleScannedBookWF"}
     def find_completed_objects
+      return to_enum(:find_completed_objects) unless block_given?
+
       completed_query = <<-EOSQL
        select distinct repository, datastream, druid
        from workflow w1
@@ -197,18 +174,15 @@ module Dor
        )
       EOSQL
 
-      rows = []
-      cursor = @conn.exec(completed_query)
-      while r = cursor.fetch_hash
-        rows << r
+      conn.fetch(completed_query) do |row|
+        yield row
       end
-      rows
     end
 
     # @param [Array<Hash>] rows result from #find_completed_objects
     # @return [Array<ArchiveCriteria>] each result mapped to an ArchiveCriteria object
     def map_result_to_criteria(rows)
-      criteria = rows.map do |r|
+      rows.lazy.map do |r|
         begin
           ArchiveCriteria.new.setup_from_query(r)
         rescue => e
@@ -216,39 +190,22 @@ module Dor
           LyberCore::Log.error("#{e.inspect}\n" + e.backtrace.join("\n"))
           nil
         end
-      end
-      criteria.reject(&:nil?)
-    end
-
-    def simple_sql_exec(sql)
-      @conn.exec(sql)
-    rescue Exception => e
-      LyberCore::Log.warn "Ignoring error: #{e.message}\n  while trying to execute: " << sql
-    end
-
-    def with_indexing_disabled(&_block)
-      simple_sql_exec('drop index ds_wf_ar_bitmap_idx')
-      simple_sql_exec('drop index repo_wf_ar_bitmap_idx')
-      yield
-    ensure
-      simple_sql_exec('create bitmap index ds_wf_ar_bitmap_idx on workflow_archive (datastream)')
-      simple_sql_exec('create bitmap index repo_wf_ar_bitmap_idx on workflow_archive (repository)')
+      end.reject { |r| r.nil? }
     end
 
     # Does the work of finding completed objects and archiving the rows
     def archive
       objs = find_completed_objects
-      if objs.size == 0
+
+      if objs.none?
         LyberCore::Log.info 'Nothing to archive'
         exit true
       end
       LyberCore::Log.info "Found #{objs.size} completed workflows"
       archiving_criteria = map_result_to_criteria(objs)
-      with_indexing_disabled { archive_rows(archiving_criteria) }
-      LyberCore::Log.info "DONE! Processed #{@archived} objects with #{@errors} errors" if @errors < 3
-    ensure
-      @conn.logoff
-      destroy_pool
+      archive_rows(archiving_criteria)
+
+      LyberCore::Log.info "DONE! Processed #{@archived.to_s} objects with #{@errors.to_s} errors" if @errors < 3
     end
   end
 end

--- a/lib/workflow-archiver.rb
+++ b/lib/workflow-archiver.rb
@@ -1,0 +1,1 @@
+require 'dor/workflow_archiver'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,52 @@
-require 'rubygems'
-require 'bundler/setup'
-
 # Make sure specs run with the definitions from test.rb
 ENV['ROBOT_ENVIRONMENT'] = 'test'
 
 require 'rspec'
-require 'dor/workflow_archiver'
+require 'workflow-archiver'
 
 LyberCore::Log.set_logfile(STDERR)
 LyberCore::Log.set_level(1)
+
+$sequel_db = Sequel.sqlite
+
+Dor::WorkflowArchiver.config.configure do
+  dor_service_uri 'http://example.com'
+end
+
+$sequel_db.create_table? :workflow do
+  primary_key :id
+  String :druid
+  String :datastream
+  String :process
+  String :status
+  String :error_msg
+  String :error_txt
+  DateTime :datetime
+  Integer :attempts
+  Decimal :elapsed
+  String :lifecycle
+  String :repository
+  String :note
+  Integer :priority
+  String :lane_id
+end
+
+$sequel_db.create_table? :workflow_archive do
+  primary_key :id
+  String :druid
+  String :datastream
+  String :process
+  String :status
+  String :error_msg
+  String :error_txt
+  DateTime :datetime
+  Integer :attempts
+  Decimal :elapsed
+  String :lifecycle
+  String :repository
+  DateTime :archive_dt
+  Integer :version
+  String :note
+  Integer :priority
+  String :lane_id
+end

--- a/spec/workflow_archiver_spec.rb
+++ b/spec/workflow_archiver_spec.rb
@@ -1,21 +1,119 @@
 require 'spec_helper'
+require 'yaml'
 
 describe Dor::WorkflowArchiver do
-  before(:each) do
-    # set login, passwords, uri
-    @login = ''
-    @pword = ''
-    @uri = ''
-    @conn = double('db_conn')
+  subject do
+    Dor::WorkflowArchiver.new(db_connection: $sequel_db)
   end
 
-  describe '#get_current_version' do
-    let!(:archiver) do
-      Dor::WorkflowArchiver.new(login: @login, password: @pword, db_uri: @uri, retry_delay: 1,
-                                dor_service_uri: 'http://sul-lyberservices-dev.stanford.edu')
+  before do
+    workflows = subject.conn.from(:workflow)
+
+    data = YAML.load <<-EOF
+---
+- :druid: integration:345
+  :datastream: googleScannedBookWF
+  :process: cleanup
+  :status: completed
+  :repository: dor
+- :druid: integration:345
+  :datastream: googleScannedBookWF
+  :process: register
+  :status: completed
+  :repository: dor
+- :druid: integration:345
+  :datastream: googleScannedBookWF
+  :process: sdr-ingest-archive
+  :status: completed
+  :repository: dor
+- :druid: integration:345
+  :datastream: googleScannedBookWF
+  :process: register-object
+  :status: completed
+  :repository: dor
+- :druid: integration:345
+  :datastream: etdSubmitWF
+  :process: cleanup
+  :status: waiting
+  :repository: dor
+- :druid: integration:345
+  :datastream: etdSubmitWF
+  :process: register
+  :status: completed
+  :repository: dor
+- :druid: integration:345
+  :datastream: sdrIngestWF
+  :process: register-sdr
+  :status: completed
+  :repository: sdr
+- :druid: integration:678
+  :datastream: googleScannedBookWF
+  :process: cleanup
+  :status: waiting
+  :repository: dor
+- :druid: integration:678
+  :datastream: googleScannedBookWF
+  :process: register
+  :status: completed
+  :repository: dor
+- :druid: integration:568
+  :datastream: sdrIngestWF
+  :process: cleanup
+  :status: completed
+  :repository: sdr
+- :druid: integration:999
+  :datastream: etdSubmitWF
+  :process: cleanup
+  :status: completed
+  :repository: sdr
+- :druid: integration:678
+  :datastream: sdrIngestWF
+  :process: register-sdr
+  :status: completed
+  :repository: 
+    EOF
+
+    data.each do |d|
+      workflows.insert d
     end
-    it "calls the DOR REST service to get the object's latest version" do
-      skip 'Nobody wrote a test'
+
+  end
+
+  after do
+    subject.conn.from(:workflow).where(Sequel.like(:druid, 'integration:%')).delete
+    subject.conn.from(:workflow_archive).where(Sequel.like(:druid, 'integration:%')).delete
+  end
+
+  describe "#find_completed_objects" do
+    let(:rows) { subject.find_completed_objects.to_a }
+
+    it 'retrieves objects that have completed all workflow steps' do
+      expect(rows.length).to eq 5
+    end
+
+    it 'includes objects that have completed all workflow steps for a given workflow' do
+      expect(rows).to include(repository: 'dor', datastream: 'googleScannedBookWF', druid: 'integration:345')
+    end
+
+    it 'excludes objects that have not completed all workflow steps' do
+      expect(rows).not_to include(repository: 'dor', datastream: 'googleScannedBookWF', druid: 'integration:678')
+      expect(rows).not_to include(repository: 'dor', datastream: 'etdSubmitWF', druid: 'integration:345')
+    end
+  end
+
+  describe '#archive_rows' do
+    before do
+      expect(RestClient).to receive(:get).at_least(:twice).with(/^#{Dor::WorkflowArchiver.config.dor_service_uri}\/dor\/v1\/objects\/integration:/).and_return('1')
+    end
+
+    it 'copies completed workflow rows to the archive table' do
+      expect { subject.archive }.to change { subject.conn.from(:workflow_archive).count }.from(0).to(8)
+      expect(subject.find_completed_objects.count).to eq 0
+
+      archived = subject.conn.from(:workflow_archive).to_a
+
+      expect(archived).to include(hash_including(druid: 'integration:678', datastream: 'sdrIngestWF'))
+      expect(archived).not_to include(hash_including(druid: 'integration:678', datastream: 'googleScannedBookWF'))
     end
   end
 end

--- a/workflow-archiver.gemspec
+++ b/workflow-archiver.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'active-fedora'
   s.add_development_dependency 'sqlite3'
 
   s.files        = Dir.glob('lib/**/*') + ['VERSION']

--- a/workflow-archiver.gemspec
+++ b/workflow-archiver.gemspec
@@ -15,10 +15,9 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
 
   # Runtime dependencies
-
   s.add_dependency 'lyber-core'
   s.add_dependency 'rest-client'
-  s.add_dependency 'ruby-oci8'
+  s.add_dependency 'sequel'
   s.add_dependency 'confstruct'
 
   s.add_development_dependency 'rake'

--- a/workflow-archiver.gemspec
+++ b/workflow-archiver.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'active-fedora'
+  s.add_development_dependency 'sqlite3'
 
   s.files        = Dir.glob('lib/**/*') + ['VERSION']
   s.require_path = 'lib'


### PR DESCRIPTION
This should allow us to write tests for this project, and downstream dependencies, without needing an oracle dependency.

This should be released as a new major version, as it requires some downstream changes, including:

- update the `db_uri` configuration to be a full database uri (including user and password info)
- include the 'oci8' gem for production environments that need oracle
- remove deprecated methods (like explicitly establishing the database connection..) from downstream code

We should also validate that adding and removing indexes on the workflow archive table is unnecessary.