### PR TITLE
V1.3.x branch:  these are the fixes currently deployed to production, with some addl fluff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - '2.1.4'
+  - '2.2.4'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+© 2017 The Board of Trustees of the Leland Stanford Junior University.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+[![Build Status](https://travis-ci.org/sul-dlss/workflow-archiver.svg?branch=master)](https://travis-ci.org/sul-dlss/workflow-archiver)
+[![Dependency Status](https://gemnasium.com/badges/github.com/sul-dlss/workflow-archiver.svg)](https://gemnasium.com/github.com/sul-dlss/workflow-archiver)
+[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/workflow-archiver/badge.svg)](https://coveralls.io/github/sul-dlss/workflow-archiver)
+[![Gem Version](https://badge.fury.io/rb/workflow-archiver.svg)](https://badge.fury.io/rb/workflow-archiver)
+
+# workflow-archiver
+
+Archives completed object workflow entries to a separate archive table.

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -262,6 +262,7 @@ module Dor
       end
 
       LyberCore::Log.info "Found #{objs.size.to_s} completed workflows"
+      objs = objs.first(500) # FIXME: temporarily limit objs processed until we fix cron not to fire if job still running
 
       archiving_criteria = map_result_to_criteria(objs)
       with_indexing_disabled { archive_rows(archiving_criteria) }

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -262,7 +262,7 @@ module Dor
       end
 
       LyberCore::Log.info "Found #{objs.size.to_s} completed workflows"
-      objs = objs.first(500) # FIXME: temporarily limit objs processed until we fix cron not to fire if job still running
+      objs = objs.first(600) # FIXME: temporarily limit objs processed until we fix cron not to fire if job still running
 
       archiving_criteria = map_result_to_criteria(objs)
       with_indexing_disabled { archive_rows(archiving_criteria) }

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -253,6 +253,7 @@ module Dor
 
     # Does the work of finding completed objects and archiving the rows
     def archive
+      connect_to_db
       objs = find_completed_objects
 
       if objs.size == 0

--- a/lib/dor/workflow_archiver.rb
+++ b/lib/dor/workflow_archiver.rb
@@ -45,7 +45,7 @@ module Dor
     # These attributes mostly used for testing
     attr_reader :conn, :errors
 
-    def WorkflowArchiver.config
+    def self.config
       @@conf ||= Confstruct::Configuration.new
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'rubygems'
 require 'bundler/setup'
 

--- a/workflow-archiver.gemspec
+++ b/workflow-archiver.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "coveralls"
   s.add_development_dependency "active-fedora"
 
   s.files        = Dir.glob("lib/**/*") + ["VERSION"]


### PR DESCRIPTION
These changes allow workflow-archiver-job to run in production (it was last deployed successfully in production at v1.3.0 in 2014)

NOTE:  
- this won't work in travis due to oracle tie in for ruby-oci8
- this approach does NOT limit the *read* of the db -- it limits the number of records we process after the giant read.  See discussion with #13 