### PR TITLE
travis.yml: fail travis faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ notifications:
 # skip travis build while tests require oracle (they don't on master branch)
 # https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
 before_install: false
+install: false # fail travis fast
 
 rvm:
 #  - '2.1.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ notifications:
 
 # skip travis build while tests require oracle (they don't on master branch)
 # https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
-before_install: false
-install: false # fail travis fast
+before_install:
+  - false # fail travis fast
+install:
+  - false # fail travis fast
 
 rvm:
 #  - '2.1.4'
   - '2.2.4'  # what's on the workflow-archiver-job production VM as of 2017-10-30
 #  - '2.4.2'  # what we'd like
+
+cache: bundler


### PR DESCRIPTION
skipping the bundle install makes the travis build fail faster.